### PR TITLE
Increase scroll padding for sticky header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -140,8 +140,8 @@
 html {
     scroll-behavior: smooth;
     font-size: 100%;
-    scroll-padding-top: 6rem;
-    /* Offset for sticky header (90px header + some margin) */
+    scroll-padding-top: 10rem;
+    /* Offset for sticky header (90px) + subtitle visibility */
 }
 
 body {


### PR DESCRIPTION
Adjusted html scroll-padding-top from 6rem to 10rem to improve visibility of content below the sticky header, ensuring subtitles are not hidden.